### PR TITLE
Remove prometheus-client runtime dependency

### DIFF
--- a/lib/yabeda/kafka/version.rb
+++ b/lib/yabeda/kafka/version.rb
@@ -2,6 +2,6 @@
 
 module Yabeda
   module Kafka
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end

--- a/yabeda-kafka.gemspec
+++ b/yabeda-kafka.gemspec
@@ -33,8 +33,7 @@ Gem::Specification.new do |spec|
 
   # TODO: remove prometheus-client dependency for kafka/monitoring
   # https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/prometheus.rb
-  spec.add_dependency 'prometheus-client'
-
+  spec.add_development_dependency 'prometheus-client'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Hi!

If we use prometheus-client-mmap instead of regular prometheus-client there's a conflict between these gems. Both rubygems use one exact constant Prometheus::Client so loading depends on LOAD_PATH. It causes undefined behaviour as we don't know which gem will be required first.

The proposed fix: remove prometheus-client from runtime gem dependency and make it optional